### PR TITLE
feat: add platform validation for widget support in Stac class

### DIFF
--- a/packages/stac/lib/src/framework/stac.dart
+++ b/packages/stac/lib/src/framework/stac.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
@@ -150,6 +151,7 @@ class Stac {
     try {
       if (json != null) {
         Map<String, dynamic>? jsonVersion = json['version'];
+        final platform = json['platform'];
 
         /// Check if has version and buildNumber is not null
         if (jsonVersion != null && StacRegistry.instance.buildNumber != null) {
@@ -160,6 +162,30 @@ class Stac {
           if (!isSatisfied) {
             Log.w(
                 'Stac buildNumber ${stacVersion.buildNumber} is not satisfied; current build is: ${StacRegistry.instance.buildNumber}');
+            return null;
+          }
+        }
+
+        /// Check if platform is specified and validate
+        if (platform != null) {
+          final currentPlatform = Platform.operatingSystem;
+          bool isPlatformSupported = false;
+          List<String> supportedPlatforms = [];
+
+          // Check if platform is a list or a single string
+          if (platform is List) {
+            supportedPlatforms = platform.map((e) => e.toString()).toList();
+            isPlatformSupported = supportedPlatforms.contains(currentPlatform);
+          } else if (platform is String) {
+            supportedPlatforms.add(platform);
+            isPlatformSupported = platform == currentPlatform;
+          }
+
+          // If platform is not supported, log and return null
+          if (!isPlatformSupported) {
+            final platformsStr = supportedPlatforms.join(', ');
+            Log.w(
+                'Widget not supported on platform [$currentPlatform]. Only available for: $platformsStr');
             return null;
           }
         }


### PR DESCRIPTION
## Description

Implemented new **platform-specific widgets** functionality in the Stac framework. It's now possible to specify on which platforms a widget should be rendered through the `platform` property in JSON.

### Features:
- **`platform` property**: Can be a single string or a list of strings
- **Automatic validation**: Checks if the current platform is in the allowed list
- **Logging**: When platform is not supported, returns `null` and logs an informative message
- **Supported platforms**: `android`, `fuchsia`, `ios`, `linux`, `macos`, `windows`

### Usage examples:

**Multiple platforms:**
```json
{
  "platform": ["android", "ios"],
  "type": "text",
  "data": "Widget only for mobile"
}
```

**Single platform:**
```json
{
  "platform": "android",
  "type": "text",
  "data": "Widget only for Android"
}
```

### Behavior:
- If current platform is allowed: widget renders normally
- If current platform is NOT allowed: returns `null` and logs:
  ```
  Widget not supported on platform [linux]. Only available for: android, ios
  ```

## Related Issues

<!--- List the related issues to this PR -->

Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore